### PR TITLE
improve Draw indicator and use RectF() to support lower SDK versions

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
 
     defaultConfig {
-        minSdkVersion 22
-        targetSdkVersion 28
+        minSdkVersion 16
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 

--- a/lib/src/main/java/me/ibrahimsn/lib/SmoothBottomBar.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/SmoothBottomBar.kt
@@ -51,6 +51,8 @@ class SmoothBottomBar : View {
     var onItemSelected: (Int) -> Unit = {}
     var onItemReselected: (Int) -> Unit = {}
 
+    private val rect = RectF()
+
     private val paintIndicator = Paint().apply {
         isAntiAlias = true
         style = Paint.Style.FILL
@@ -147,11 +149,11 @@ class SmoothBottomBar : View {
         }
 
         // Draw indicator
-        canvas.drawRoundRect(indicatorLocation,
-            items[activeItem].rect.centerY() - itemIconSize/2 - itemPadding,
-            indicatorLocation + itemWidth,
-            items[activeItem].rect.centerY() + itemIconSize/2 + itemPadding,
-            20f, 20f, paintIndicator)
+        rect.left = indicatorLocation
+        rect.top = items[activeItem].rect.centerY() - itemIconSize/2 - itemPadding
+        rect.right = indicatorLocation + itemWidth
+        rect.bottom = items[activeItem].rect.centerY() + itemIconSize/2 + itemPadding
+        canvas.drawRoundRect(rect, 20f, 20f, paintIndicator)
     }
 
     /**


### PR DESCRIPTION
use `RectF()` in `drawRoundRect()` to use this library in lower SDK version.
Thanks for compare and accept the pull request.