### PR TITLE
improve Draw indicator and use RectF() to support lower sdk versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "me.ibrahimsn.smoothbottombar"
-        minSdkVersion 22
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,7 +6,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/lib/src/main/java/me/ibrahimsn/lib/SmoothBottomBar.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/SmoothBottomBar.kt
@@ -51,6 +51,8 @@ class SmoothBottomBar : View {
     var onItemSelected: (Int) -> Unit = {}
     var onItemReselected: (Int) -> Unit = {}
 
+    val rect = RectF()
+
     private val paintIndicator = Paint().apply {
         isAntiAlias = true
         style = Paint.Style.FILL
@@ -147,11 +149,11 @@ class SmoothBottomBar : View {
         }
 
         // Draw indicator
-        canvas.drawRoundRect(indicatorLocation,
-            items[activeItem].rect.centerY() - itemIconSize/2 - itemPadding,
-            indicatorLocation + itemWidth,
-            items[activeItem].rect.centerY() + itemIconSize/2 + itemPadding,
-            20f, 20f, paintIndicator)
+        rect.left = indicatorLocation
+        rect.top = items[activeItem].rect.centerY() - itemIconSize/2 - itemPadding
+        rect.right = indicatorLocation + itemWidth
+        rect.bottom = items[activeItem].rect.centerY() + itemIconSize/2 + itemPadding
+        canvas.drawRoundRect(rect, 20f, 20f, paintIndicator)
     }
 
     /**


### PR DESCRIPTION
Add `RectF()` and use it in `drawRoundRect()` to decrease minSdkVersion  for draw indicator.
thanks for the accept pull request.