### PR TITLE
Add badge to bottom bar item

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ bottomBar.setOnItemReselectedListener(object: OnItemReselectedListener {
 })
 ```
 
+-   Add badge to a specific item
+```kotlin
+bottomBar.setBadge(1, Badge(
+    badgeSize = 20F,
+    badgeBoxCornerRadius = 8F,
+    badgeColor = ContextCompat.getColor(this , R.color.colorBadge),
+    badgeText = "99+",
+    badgeTextColor = Color.BLACK,
+    badgeType = BadgeType.BOX // or BadgeType.CIRCLE
+))
+
+bottomBar.removeBadge(1)
+```
+
 ## Customization
 
 ```xml

--- a/app/src/main/java/me/ibrahimsn/smoothbottombar/MainActivity.kt
+++ b/app/src/main/java/me/ibrahimsn/smoothbottombar/MainActivity.kt
@@ -1,8 +1,12 @@
 package me.ibrahimsn.smoothbottombar
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import kotlinx.android.synthetic.main.activity_main.*
+import me.ibrahimsn.lib.Badge
+import me.ibrahimsn.lib.BadgeType
 
 class MainActivity : AppCompatActivity(R.layout.activity_main) {
 
@@ -16,5 +20,27 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         bottomBar.onItemReselected = {
             status.text = "Item $it re-selected"
         }
+
+        // Delay 1 second before drawing the badges ( just to notice the animation )
+        bottomBar.postDelayed({
+            bottomBar.setBadge(0, Badge(
+                badgeSize = 12F,
+                badgeColor = ContextCompat.getColor(this , R.color.colorBadge)
+            ))
+
+            bottomBar.setBadge(1, Badge(
+                badgeSize = 20F,
+                badgeBoxCornerRadius = 8F,
+                badgeColor = ContextCompat.getColor(this , R.color.colorBadge),
+                badgeText = "99+",
+                badgeTextColor = Color.BLACK,
+                badgeType = BadgeType.BOX
+            ))
+        } , 1000);
+
+        // Remove the badge from item at index 0 after 4 seconds
+        bottomBar.postDelayed({
+            bottomBar.removeBadge(0)
+        } , 4000);
     }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,4 +6,5 @@
 
     <color name="colorTextPrimary">#ffffff</color>
     <color name="colorTextSecondary">#A3FFFFFF</color>
+    <color name="colorBadge">#f4d415</color>
 </resources>

--- a/lib/src/main/java/me/ibrahimsn/lib/Badge.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/Badge.kt
@@ -1,0 +1,16 @@
+package me.ibrahimsn.lib
+
+import android.graphics.Color
+
+/**
+ * Created by BrookMG on 4/8/2020 in me.ibrahimsn.lib
+inside the project SmoothBottomBar .
+ */
+data class Badge (
+    var badgeSize: Float,
+    var badgeText: String = "",
+    var badgeColor: Int,
+    var badgeTextColor: Int = Color.BLACK,
+    var badgeBoxCornerRadius: Float = 8F,
+    var badgeType: BadgeType = BadgeType.CIRCLE
+)

--- a/lib/src/main/java/me/ibrahimsn/lib/BadgeType.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/BadgeType.kt
@@ -1,0 +1,9 @@
+package me.ibrahimsn.lib
+
+/**
+ * Created by BrookMG on 4/8/2020 in me.ibrahimsn.lib
+inside the project SmoothBottomBar .
+ */
+enum class BadgeType {
+    CIRCLE , BOX
+}

--- a/lib/src/main/java/me/ibrahimsn/lib/BottomBarItem.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/BottomBarItem.kt
@@ -7,5 +7,6 @@ data class BottomBarItem(
     var title: String,
     val icon: Drawable,
     var rect: RectF = RectF(),
-    var alpha: Int
+    var alpha: Int,
+    var badge: Badge?
 )

--- a/lib/src/main/java/me/ibrahimsn/lib/BottomBarParser.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/BottomBarParser.kt
@@ -50,6 +50,6 @@ class BottomBarParser(private val context: Context, @XmlRes res: Int) {
         if (itemDrawable == null)
             throw Throwable("Item icon can not be null!")
 
-        return BottomBarItem(itemText ?: "", itemDrawable, alpha = 0)
+        return BottomBarItem(itemText ?: "", itemDrawable, alpha = 0, badge = null)
     }
 }

--- a/lib/src/main/java/me/ibrahimsn/lib/SmoothBottomBar.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/SmoothBottomBar.kt
@@ -260,6 +260,48 @@ class SmoothBottomBar : View {
         }
     }
 
+    // Add item badge
+    fun setBadge(pos: Int, badge: Badge) {
+        if (pos >= 0 && pos < items.size && badge.badgeSize > 0f) {
+            items[pos].badge = badge
+
+            val animator = ValueAnimator.ofFloat(0f, badge.badgeSize)
+            animator.duration = 100
+
+            animator.addUpdateListener { animation ->
+                items[pos].badge?.badgeSize = animation.animatedValue as Float
+                invalidate()
+            }
+
+            animator.start()
+        }
+    }
+
+    fun getBadge(pos: Int) : Badge? {
+        return if (pos >= 0 && pos < items.size) items[pos].badge else null
+    }
+
+    // Remove item badge
+    fun removeBadge(pos: Int) {
+        if (pos >= 0 && pos < items.size && items[pos].badge != null && items[pos].badge?.badgeSize!! > 0f) {
+            val animator = ValueAnimator.ofFloat(items[pos].badge?.badgeSize!!, 0f)
+            animator.duration = 100
+            animator.addUpdateListener {
+                animation -> items[pos].badge?.badgeSize = animation.animatedValue as Float
+                invalidate()
+            }
+
+            animator.addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    super.onAnimationEnd(animation)
+                    items[pos].badge = null
+                }
+            })
+
+            animator.start()
+        }
+    }
+
     /**
      * Handle item clicks
      */


### PR DESCRIPTION
+ It's possible now to add a badge to a bottom bar item using the `setBadge` method which accepts the index and Badge object
+ A badge object can be of two types. `CIRCLE` or `BOX`.
+ The circle badge is useful to get the user attention for minor occurrences. it's not advised for badges with text content.
+ The box badge can be used to display a badge with text. It's better if the length of the text is limited to 3 characters or less. 
+ Fixes #13  