### PR TITLE
Added text slide feature.

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,6 +33,7 @@
         app:iconTint="#C8FFFFFF"
         app:iconTintActive="#FFFFFF"
         app:menu="@menu/menu_bottom"
+        app:textSlide="true"
         app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/lib/src/main/java/me/ibrahimsn/lib/BottomBarItem.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/BottomBarItem.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable
 
 data class BottomBarItem (
     var title: String,
+    var titleShortened : String,
     val icon: Drawable,
     var rect: RectF = RectF(),
     var alpha: Int

--- a/lib/src/main/java/me/ibrahimsn/lib/BottomBarParser.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/BottomBarParser.kt
@@ -51,7 +51,7 @@ class BottomBarParser(private val context: Context, @XmlRes res: Int) {
         if (itemDrawable == null)
             throw Throwable("Item icon can not be null!")
 
-        return BottomBarItem(itemText ?: "", itemDrawable, alpha = 0)
+        return BottomBarItem(itemText ?: "", itemText ?: "", itemDrawable, alpha = 0)
     }
 
     companion object {

--- a/lib/src/main/java/me/ibrahimsn/lib/SmoothBottomBar.kt
+++ b/lib/src/main/java/me/ibrahimsn/lib/SmoothBottomBar.kt
@@ -370,6 +370,8 @@ class SmoothBottomBar @JvmOverloads constructor(
 
             // At first, we assume that text is never shortened
             itemsIsTextShortened.add(i, false)
+            textTranslationAnimator =
+                ValueAnimator.ofFloat(0F, items[itemActiveIndex].rect.width())
 
             // Prevent text overflow by shortening the item title
             var shorted = false
@@ -383,9 +385,6 @@ class SmoothBottomBar @JvmOverloads constructor(
                 item.titleShortened = item.titleShortened.dropLast(1)
                 item.titleShortened += context.getString(R.string.ellipsis)
                 itemsIsTextShortened[i] = true
-
-                textTranslationAnimator =
-                    ValueAnimator.ofFloat(0F, items[itemActiveIndex].rect.width())
             }
 
 
@@ -460,7 +459,7 @@ class SmoothBottomBar @JvmOverloads constructor(
                     (items[itemActiveIndex].rect.right - barSideMargins).toInt(),
                     height
                 )
-                
+
                 var titleToDraw = item.titleShortened
                 if (itemTextSlide) {
                     titleToDraw = item.title

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -18,6 +18,7 @@
         <attr name="cornerRadius" format="dimension" />
         <attr name="activeItem" format="integer" />
         <attr name="duration" format="integer" />
+        <attr name="textSlide" format="boolean" />
     </declare-styleable>
 
     <attr name="SmoothBottomBarStyle" format="reference" />


### PR DESCRIPTION
### **New text slide feature** ###

We can turn on text slide for titles that go out of bounds:
`app:textSlide="true"`

This will cause the text to not be shortened and instead be displayed entirely but sliding across the menu item.


[#hacktoberfest](https://hacktoberfest.digitalocean.com)