### PR TITLE
Increase README setup dependecy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ allprojects {
 }
 //app label build.gradle
 dependencies {
-        implementation 'com.github.ibrahimsn98:SmoothBottomBar:1.7.8'
+        implementation 'com.github.ibrahimsn98:SmoothBottomBar:1.7.9'
 }
 ```
 


### PR DESCRIPTION
Following the 1.7.9 update, the setup dependency version of the README needs to update.

- `1.7.8` -> `1.7.9`